### PR TITLE
SOLAPI Kotlin SDK 1.0.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "com.solapi"
-version = "1.0.2"
+version = "1.0.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/solapi/sdk/message/dto/response/kakao/KakaoAlimtalkTemplateResponse.kt
+++ b/src/main/java/com/solapi/sdk/message/dto/response/kakao/KakaoAlimtalkTemplateResponse.kt
@@ -1,9 +1,7 @@
 package com.solapi.sdk.message.dto.response.kakao
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import com.solapi.sdk.message.model.kakao.*
-import java.time.Instant
 
 @Serializable
 data class KakaoAlimtalkTemplateResponse(
@@ -37,11 +35,9 @@ data class KakaoAlimtalkTemplateResponse(
     var header: String? = null,
     var variables: List<KakaoAlimtalkTemplateVariable>? = null,
 
-    @Contextual
-    var dateCreated: Instant? = null,
+    var dateCreated: String? = null,
 
-    @Contextual
-    var dateUpdated: Instant? = null
+    var dateUpdated: String? = null
 ) {
     @Serializable
     data class KakaoAlimtalkTemplateComment(

--- a/src/main/java/com/solapi/sdk/message/model/Message.kt
+++ b/src/main/java/com/solapi/sdk/message/model/Message.kt
@@ -1,7 +1,5 @@
 package com.solapi.sdk.message.model
 
-import kotlinx.serialization.Contextual
-import java.time.LocalDateTime
 import kotlinx.serialization.Serializable
 import com.solapi.sdk.message.model.fax.FaxOption
 import com.solapi.sdk.message.model.kakao.KakaoOption
@@ -51,20 +49,17 @@ data class Message (
     /**
      *     * 발송 접수일자
      */
-    @Contextual
-    var dateProcessed: LocalDateTime? = null,
+    var dateProcessed: String? = null,
 
     /**
      * 통신사 결과 값 통보일자
      */
-    @Contextual
-    var dateReported: LocalDateTime? = null,
+    var dateReported: String? = null,
 
     /**
      * 실제 메시지 발송 완료일자
      */
-    @Contextual
-    var dateReceived: LocalDateTime? = null,
+    var dateReceived: String? = null,
 
     /**
      * 메시지 상태코드
@@ -112,14 +107,12 @@ data class Message (
     /**
      * 메시지 생성일자
      */
-    @Contextual
-    var dateCreated: LocalDateTime? = null,
+    var dateCreated: String? = null,
 
     /**
      * 메시지 수정일자
      */
-    @Contextual
-    var dateUpdated: LocalDateTime? = null,
+    var dateUpdated: String? = null,
 
     /**
      * 수신번호

--- a/src/main/java/com/solapi/sdk/message/model/group/GroupInfo.kt
+++ b/src/main/java/com/solapi/sdk/message/model/group/GroupInfo.kt
@@ -1,7 +1,5 @@
 package com.solapi.sdk.message.model.group
 
-import kotlinx.serialization.Contextual
-import java.time.LocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -32,12 +30,8 @@ data class GroupInfo(
     var groupId: String? = null,
     var price: Map<String, PriceInfoDetail>? = null,
 
-    @Contextual
-    var dateSent: LocalDateTime? = null,
-    @Contextual
-    var dateCreated: LocalDateTime? = null,
-    @Contextual
-    var dateUpdated: LocalDateTime? = null,
-    @Contextual
-    var dateCompleted: LocalDateTime? = null
+    var dateSent: String? = null,
+    var dateCreated: String? = null,
+    var dateUpdated: String? = null,
+    var dateCompleted: String? = null
 )

--- a/src/main/java/com/solapi/sdk/message/model/kakao/KakaoAlimtalkTemplateCodeList.kt
+++ b/src/main/java/com/solapi/sdk/message/model/kakao/KakaoAlimtalkTemplateCodeList.kt
@@ -1,8 +1,6 @@
 package com.solapi.sdk.message.model.kakao
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
-import java.time.Instant
 
 @Serializable
 data class KakaoAlimtalkTemplateCodeList(
@@ -19,7 +17,6 @@ data class KakaoAlimtalkTemplateCodeList(
         var memberId: String? = null,
         var isAdmin: Boolean? = null,
         var content: String? = null,
-        @Contextual
-        var dateCreated: Instant? = null
+        var dateCreated: String? = null
     )
 }

--- a/src/main/java/com/solapi/sdk/message/model/kakao/KakaoBrandMessageTemplate.kt
+++ b/src/main/java/com/solapi/sdk/message/model/kakao/KakaoBrandMessageTemplate.kt
@@ -1,8 +1,6 @@
 package com.solapi.sdk.message.model.kakao
 
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
-import java.time.Instant
 
 @Serializable
 data class KakaoBrandMessageTemplate(
@@ -43,10 +41,8 @@ data class KakaoBrandMessageTemplate(
     var allowCopy: Boolean? = null,
 
     // 생성/수정 일시
-    @Contextual
-    var dateCreated: Instant? = null,
-    @Contextual
-    var dateUpdated: Instant? = null
+    var dateCreated: String? = null,
+    var dateUpdated: String? = null
 ) {
 
     @Serializable


### PR DESCRIPTION
## Hot fix
- Spring Framework에서 역직렬화 할 때 `kotlinx.serialization`과 `jackson` 라이브러리가 충돌하여 Instant, LocalDateTime 타입이 제대로 역직렬화 되지 않던 문제를 해결했습니다.